### PR TITLE
Update Ktor Feature demo, add static route example

### DIFF
--- a/ktorFeature/build.gradle
+++ b/ktorFeature/build.gradle
@@ -15,6 +15,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.kwebio:kweb-core:0.7.21'
+    implementation 'com.github.kwebio:kweb-core:0.8.1'
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 }

--- a/ktorFeature/src/FeatureApp.kt
+++ b/ktorFeature/src/FeatureApp.kt
@@ -15,7 +15,7 @@ import kweb.state.KVar
 import java.time.Duration
 
 fun main() {
-    embeddedServer(Jetty, port = 16098, module = Application::kwebFeature).start()
+    embeddedServer(Jetty, port = 16097, module = Application::kwebFeature).start()
 }
 
 private fun Application.kwebFeature() {

--- a/ktorFeature/src/FeatureApp.kt
+++ b/ktorFeature/src/FeatureApp.kt
@@ -1,11 +1,12 @@
 package kweb.demos.feature
 
-import io.ktor.application.Application
-import io.ktor.application.install
+import io.ktor.application.*
 import io.ktor.features.Compression
 import io.ktor.features.DefaultHeaders
 import io.ktor.http.cio.websocket.pingPeriod
 import io.ktor.http.cio.websocket.timeout
+import io.ktor.response.*
+import io.ktor.routing.*
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.jetty.Jetty
 import io.ktor.websocket.WebSockets
@@ -14,7 +15,7 @@ import kweb.state.KVar
 import java.time.Duration
 
 fun main() {
-    embeddedServer(Jetty, port = 16097, module = Application::kwebFeature).start()
+    embeddedServer(Jetty, port = 16098, module = Application::kwebFeature).start()
 }
 
 private fun Application.kwebFeature() {
@@ -25,19 +26,31 @@ private fun Application.kwebFeature() {
         timeout = Duration.ofSeconds(30)
     }
 
-    install(Kweb) {
-        buildPage = {
-            doc.body.new {
-                val greeting = url.map { it.removePrefix("/") }.map { "Hello " + if (it.isNotBlank()) it else "World" }
+    install(Kweb)
 
-                val next = KVar("")
+    routing {
+        get("/staticpage") {
+            call.respondText("This is a static page and it won't be routed via Kweb")
+        }
+    }
 
-                h1().text(greeting)
-                span().text("Where to next?")
-                input().setValue(next)
-                button().text("Go!").on.click {
-                    url.value = next.value
-                }
+    // You can also do:
+    // routing {
+    //     get("/{visitedUrl...}") {
+    //         call.respondKweb(buildPage)
+    //     }
+    // }
+    installKwebOnRemainingRoutes {
+        doc.body.new {
+            val greeting = url.map { it.removePrefix("/") }.map { "Hello " + if (it.isNotBlank()) it else "World" }
+
+            val next = KVar("")
+
+            h1().text(greeting)
+            span().text("Where to next?")
+            input().setValue(next)
+            button().text("Go!").on.click {
+                url.value = next.value
             }
         }
     }


### PR DESCRIPTION
Updates the Ktor Feature demo to `0.8.1` and adds a `/staticpage` route, showing that you can register static routes in Ktor if you don't want to use Kweb for a specific route.